### PR TITLE
feature/sdcc-port: SDCC build system, CI, engineering README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+    branches: [ feature/sdcc-port ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SDCC
+        run: sudo apt-get update && sudo apt-get install -y sdcc python3
+
+      - name: Build
+        run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install SDCC
-        run: sudo apt-get update && sudo apt-get install -y sdcc python3
+      - name: Cache SDCC toolchain
+        id: cache-sdcc
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/sdcc
+          key: sdcc-4.2.0-linux-amd64
+
+      - name: Install SDCC toolchain
+        if: steps.cache-sdcc.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget bzip2
+          mkdir -p /home/runner/sdcc
+          wget -qO- "https://sourceforge.net/projects/sdcc/files/sdcc-linux-amd64/4.2.0/sdcc-4.2.0-amd64-unknown-linux2.5.tar.bz2/download" \
+            | tar -xjf - -C /home/runner/sdcc --strip=1
+
+      - name: Add SDCC to PATH
+        run: echo "/home/runner/sdcc/bin" >> $GITHUB_PATH
 
       - name: Build
         run: make

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      = sdcc
 CFLAGS  = -mstm8 --out-fmt-ihx -Iinc --all-callee-saves
-LDFLAGS = -mstm8 --out-fmt-ihx --iram-size 1024 --xram-size 0 --code-size 16384
+LDFLAGS = -mstm8 -Iinc --iram-size 1024 --xram-size 0 --code-size 16384
 
 SRC_DIR = src
 BUILD_DIR = build
@@ -21,8 +21,8 @@ $(BUILD_DIR)/%_patched.c: $(SRC_DIR)/%.c inc/iostm8s003f3.h | $(BUILD_DIR)
 $(TARGET).ihx: $(C_PATCHED)
 	$(CC) $(CFLAGS) $(C_PATCHED) -o $@
 
-$(TARGET).hex: $(TARGET).ihx
-	$(CC) $(LDFLAGS) $(C_PATCHED) -o $@
+$(TARGET).hex: $(BUILD_DIR)/firmware.ihx
+	packihx $(BUILD_DIR)/firmware.ihx > $@
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+CC      = sdcc
+CFLAGS  = -mstm8 --std-c99 --out-fmt-ihx -Iinc --all-callee-saves
+LDFLAGS = -mstm8 --out-fmt-ihx --iram-size 1024 --xram-size 0 --code-size 16384
+
+SRC_DIR = src
+BUILD_DIR = build
+TARGET  = $(BUILD_DIR)/firmware
+
+C_SOURCES = $(wildcard $(SRC_DIR)/*.c)
+C_PATCHED = $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=_patched.c)))
+
+.PHONY: all preprocess clean
+
+all: $(TARGET).hex
+
+preprocess: $(C_PATCHED)
+
+$(BUILD_DIR)/%_patched.c: $(SRC_DIR)/%.c inc/iostm8s003f3.h | $(BUILD_DIR)
+	python3 iar2sdcc.py $< $@
+
+$(TARGET).ihx: $(C_PATCHED)
+	$(CC) $(CFLAGS) $(C_PATCHED) -o $@
+
+$(TARGET).hex: $(TARGET).ihx
+	$(CC) $(LDFLAGS) $(C_PATCHED) -o $@
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR) *.asm *.lst *.map *.lk *.sym *.adb *.cdb *.ihx

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC      = sdcc
-CFLAGS  = -mstm8 --std-c99 --out-fmt-ihx -Iinc --all-callee-saves
+CFLAGS  = -mstm8 --out-fmt-ihx -Iinc --all-callee-saves
 LDFLAGS = -mstm8 --out-fmt-ihx --iram-size 1024 --xram-size 0 --code-size 16384
 
 SRC_DIR = src

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This branch adds **SDCC**-based build system with `iar2sdcc.py` preprocessing, e
 - nRF24L01+ in Enhanced ShockBurst RX mode, dynamic payload length, NoACK
 - 3-byte address width, channel 99, 2 Mbps, 16-bit CRC
 - Decodes multisensor composite packets: pressure, temperature, humidity, illuminance, VBAT, die temperature
-- Clock scaling for power saving: 16 MHz → 2 MHz during IRQ wait
+- Clock scaling for power saving: 16 MHz to 2 MHz during IRQ wait
 - Peripheral clock gating: SPI/UART clocked only when active
 - Independent watchdog (IWDG) with LSI, kicked every idle loop iteration
 - Receives all available payloads from RX FIFO in burst
@@ -49,7 +49,6 @@ Open `Project.eww` in IAR EWSTM8.
 | NRF_CE | PD3 | GPIO output, chip enable, active high |
 | SPI_SCK | PD0 | |
 | SPI_MISO | PD1 | |
-| SPI_MOSI | PD2 | (shared with CSN on some STM8S variants - verify schematic) |
 | UART_TX | PD5 | 115200 baud |
 
 ## Radio Protocol
@@ -94,12 +93,12 @@ The receiver decodes the following payload fields (7-11 bytes):
   +-------------------+
      |
   +=================================+
-  |     Main loop                  |
+  |     Main loop                   |
   |  CLK_CKDIVR = SLOW (2 MHz)     |
-  |  CLOCK_DISABLE(SPI)            |
-  |  while (IRQ line HIGH) {       |
-  |      IWDG refresh              |
-  |  }                             |
+  |  CLOCK_DISABLE(SPI)             |
+  |  while (IRQ line HIGH) {        |
+  |      IWDG refresh               |
+  |  }                              |
   +=================================+
      |                         ^
      | IRQ goes LOW            |
@@ -110,20 +109,20 @@ The receiver decodes the following payload fields (7-11 bytes):
   +-------------------+       |
      v                         |
   +-------------------+       |
-  | RX FIFO loop:      |       |
-  | do {               |       |
-  |   nrf_get_size()  |       |
-  |   if >32 flush    |       |
-  |   nrf_read_payload |       |
-  |   decode fields   |       |
-  |   uprintf values  |       |
-  | } while (!RX_EMPTY)|       |
+  | RX FIFO loop      |       |
+  | do {              |       |
+  |  nrf_get_size()  |       |
+  |  if >32 flush    |       |
+  | nrf_read_payload |       |
+  | decode fields    |       |
+  | uprintf values   |       |
+  |} while(!RX_EMPTY)|       |
   +-------------------+       |
      |                         |
      v                         |
   +-------------------+       |
-  | CLR RX_DR         |-------+
-  | CLOCK_DISABLE(UART)|
+  | CLR RX_DR         |       |
+  | DISABLE_UART      |-------+
   +-------------------+
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,36 +94,36 @@ The receiver decodes the following payload fields (7-11 bytes):
      |
   +=================================+
   |     Main loop                   |
-  |  CLK_CKDIVR = SLOW (2 MHz)     |
+  |  CLK_CKDIVR = SLOW (2 MHz)      |
   |  CLOCK_DISABLE(SPI)             |
   |  while (IRQ line HIGH) {        |
   |      IWDG refresh               |
   |  }                              |
   +=================================+
-     |                         ^
-     | IRQ goes LOW            |
-     v                         |
-  +-------------------+       |
-  | CLK = NORMAL      |       |
-  | CLOCK_ENABLE(SPI) |       |
-  +-------------------+       |
-     v                         |
-  +-------------------+       |
-  | RX FIFO loop      |       |
-  | do {              |       |
-  |  nrf_get_size()  |       |
-  |  if >32 flush    |       |
-  | nrf_read_payload |       |
-  | decode fields    |       |
-  | uprintf values   |       |
-  |} while(!RX_EMPTY)|       |
-  +-------------------+       |
-     |                         |
-     v                         |
-  +-------------------+       |
-  | CLR RX_DR         |       |
-  | DISABLE_UART      |-------+
-  +-------------------+
+     |                              ^
+     | IRQ goes LOW                 |
+     v                              |
+  +-------------------+             |
+  | CLK = NORMAL      |             |
+  | CLOCK_ENABLE(SPI) |             |
+  +-------------------+             |
+     v                              |
+  +-------------------+             |
+  | RX FIFO loop      |             |
+  | do {              |             |
+  |   nrf_get_size()  |             |
+  |   if >32 flush    |             |
+  | nrf_read_payload  |             |
+  |   decode fields   |             |
+  |   uprintf values  |             |
+  | } while(!RX_EMPTY)|             |
+  +-------------------+             |
+     |                              |
+     v                              |
+  +-------------------+             |
+  | CLR RX_DR         |             |
+  | DISABLE_UART      |-------------+
+  +-------------------+             |
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -1,9 +1,141 @@
 # STM8S-NRF24L01-RECEIVER
 
-Simple __STM8S__ based 2.4 GHz __nRF24L01+__ receiver
+[![Build](https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml/badge.svg?branch=feature/sdcc-port)](https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml) [![MCU](https://img.shields.io/badge/MCU-STM8S003F3-00A9E0)]() [![Radio](https://img.shields.io/badge/Radio-nRF24L01-00A9E0)]() [![Toolchain](https://img.shields.io/badge/Toolchain-SDCC-00A9E0)]() [![License](https://img.shields.io/badge/License-MIT-yellow)]()
 
-The receiver listens the radio channel specified and prints in HEX all the data it receives.
+Wireless nRF24L01+ receiver based on STM8S003F3. Listens on RF channel 99, receives variable-length dynamic payloads, decodes sensor data (BMP180 pressure/temperature, SI7021 humidity/temperature, BH1750 light, battery voltage, die temperature) and prints the values over UART at 115200 baud.
 
-Receiver mode: 2mbit, 16bit CRC.
+This branch adds **SDCC**-based build system with `iar2sdcc.py` preprocessing, enabling CI on GitHub Actions without a commercial IAR license.
 
-PROTEUS Project file _"NRF24L01 STM8S RECEIVER 2.00.pdsprj"_ contains the circuit and PCB design.
+## Features
+
+- Register-level, bare-metal firmware (no HAL, no SPL)
+- nRF24L01+ in Enhanced ShockBurst RX mode, dynamic payload length, NoACK
+- 3-byte address width, channel 99, 2 Mbps, 16-bit CRC
+- Decodes multisensor composite packets: pressure, temperature, humidity, illuminance, VBAT, die temperature
+- Clock scaling for power saving: 16 MHz → 2 MHz during IRQ wait
+- Peripheral clock gating: SPI/UART clocked only when active
+- Independent watchdog (IWDG) with LSI, kicked every idle loop iteration
+- Receives all available payloads from RX FIFO in burst
+- Proteus simulation project included
+
+## Build
+
+### SDCC (this branch)
+
+```sh
+make
+```
+
+Requires: `sdcc`, `python3`, `packihx`.
+
+### IAR Embedded Workbench (master branch)
+
+Open `Project.eww` in IAR EWSTM8.
+
+## Hardware Specification
+
+| Component | Detail |
+|-----------|--------|
+| MCU | STMicroelectronics STM8S003F3 (STM8S, 8 KB Flash, 1 KB RAM) |
+| Radio | Nordic nRF24L01+ (SPI, 1 MHz, channel 99, PRX mode) |
+| Clock | HSI 16 MHz |
+
+## Pin Assignment
+
+| Signal | Pin | Notes |
+|--------|-----|-------|
+| NRF_IRQ | PC4 | GPIO input, floating, active low |
+| NRF_CSN | PD2 | GPIO output, SPI chip select, active low |
+| NRF_CE | PD3 | GPIO output, chip enable, active high |
+| SPI_SCK | PD0 | |
+| SPI_MISO | PD1 | |
+| SPI_MOSI | PD2 | (shared with CSN on some STM8S variants - verify schematic) |
+| UART_TX | PD5 | 115200 baud |
+
+## Radio Protocol
+
+| Parameter | Value |
+|-----------|-------|
+| RF Channel | 99 |
+| Air data rate | 2 Mbps |
+| Address width | 3 bytes |
+| CRC | 2 bytes (CRC16) |
+| Auto-ACK | Disabled |
+| Dynamic payload | Enabled |
+
+The receiver decodes the following payload fields (7-11 bytes):
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0-2 | 3 bytes | BMP180 pressure (big-endian) |
+| 3 | 1 byte | Die temperature (signed) |
+| 4-5 | 2 bytes | SI7021 temperature (signed, C x 100) |
+| 6-7 | 2 bytes | SI7021 humidity (RH x 100) |
+| 8-9 | 2 bytes | VBAT (mV) |
+
+## Firmware Architecture
+
+```
+  Cold boot
+     |
+  +-------------------+
+  | CLK_CKDIVR = FAST |  16 MHz
+  | Periph clocks ON  |
+  | IWDG init         |
+  | GPIO init         |
+  | SPI init          |
+  | UART init (115200)|
+  | nRF24L01+ init    |
+  +-------------------+
+     |
+  +-------------------+
+  | nRF24L01 detect   |
+  | (FIFO test)       |
+  +-------------------+
+     |
+  +=================================+
+  |     Main loop                  |
+  |  CLK_CKDIVR = SLOW (2 MHz)     |
+  |  CLOCK_DISABLE(SPI)            |
+  |  while (IRQ line HIGH) {       |
+  |      IWDG refresh              |
+  |  }                             |
+  +=================================+
+     |                         ^
+     | IRQ goes LOW            |
+     v                         |
+  +-------------------+       |
+  | CLK = NORMAL      |       |
+  | CLOCK_ENABLE(SPI) |       |
+  +-------------------+       |
+     v                         |
+  +-------------------+       |
+  | RX FIFO loop:      |       |
+  | do {               |       |
+  |   nrf_get_size()  |       |
+  |   if >32 flush    |       |
+  |   nrf_read_payload |       |
+  |   decode fields   |       |
+  |   uprintf values  |       |
+  | } while (!RX_EMPTY)|       |
+  +-------------------+       |
+     |                         |
+     v                         |
+  +-------------------+       |
+  | CLR RX_DR         |-------+
+  | CLOCK_DISABLE(UART)|
+  +-------------------+
+```
+
+## Project Structure
+
+```
+src/
++-- main.c                  Application entry + all drivers
+inc/
++-- iostm8s003f3.h          SDCC-compatible register map (__at + bitfields)
+iar2sdcc.py                 Patch script (IAR -> SDCC)
+Makefile                    SDCC build
+Project.eww / .ewp / .ewd   IAR Embedded Workbench project
+*.pdsprj                    Proteus simulation
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # STM8S-NRF24L01-RECEIVER
 
-[![Build](https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml/badge.svg?branch=feature/sdcc-port)](https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml) [![MCU](https://img.shields.io/badge/MCU-STM8S003F3-00A9E0)]() [![Radio](https://img.shields.io/badge/Radio-nRF24L01-00A9E0)]() [![Toolchain](https://img.shields.io/badge/Toolchain-SDCC-00A9E0)]() [![License](https://img.shields.io/badge/License-MIT-yellow)]()
+[![Build](https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml/badge.svg?branch=feature/sdcc-port)](https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml) [![MCU](https://img.shields.io/badge/MCU-STM8S003F3-00A9E0)]() [![Radio](https://img.shields.io/badge/Radio-nRF24L01-00A9E0)]() [![License](https://img.shields.io/badge/License-MIT-yellow)]()
 
 Wireless nRF24L01+ receiver based on STM8S003F3. Listens on RF channel 99, receives variable-length dynamic payloads, decodes sensor data (BMP180 pressure/temperature, SI7021 humidity/temperature, BH1750 light, battery voltage, die temperature) and prints the values over UART at 115200 baud.
-
-This branch adds **SDCC**-based build system with `iar2sdcc.py` preprocessing, enabling CI on GitHub Actions without a commercial IAR license.
 
 ## Features
 
@@ -20,17 +18,37 @@ This branch adds **SDCC**-based build system with `iar2sdcc.py` preprocessing, e
 
 ## Build
 
-### SDCC (this branch)
+Two compilers are supported: **SDCC** (free, cross-platform, CI-ready) and **IAR Embedded Workbench for STM8** (commercial, Windows-only).
+
+| Feature               | SDCC                                       | IAR EWSTM8                                 |
+|-----------------------|--------------------------------------------|--------------------------------------------|
+| Compiler              | `sdcc` 4.2.x                               | `iccstm8`                                  |
+| License               | GPLv2 (free)                               | Commercial (paid license required)         |
+| Host OS               | Linux, macOS, Windows                      | Windows only                               |
+| Command               | `make`                                     | Open `Project.eww` in IDE                  |
+| Preprocessing         | `iar2sdcc.py` patches IAR idioms           | None (native IAR project)                  |
+| Output                | Intel HEX via `packihx`                    | Intel HEX / Debug (IAR format)             |
+| Debug                 | No (standalone build)                      | Full (IAR C-SPY debugger, simulator)       |
+| CI (GitHub Actions)   | Yes (SDCC tarball cached)                  | No                                         |
+
+### SDCC (recommended)
 
 ```sh
 make
 ```
 
-Requires: `sdcc`, `python3`, `packihx`.
+Requires: `sdcc` ≥4.2.0, `python3` ≥3.6, `packihx` (included with SDCC).
 
-### IAR Embedded Workbench (master branch)
+The build process:
+1. `iar2sdcc.py` preprocesses `src/main.c` — patches `SPI_CR1_BR` bitfield access (IAR-specific) to read-modify-write, and replaces `snprintf` with `sprintf` (SDCC's STM8 libc lacks `snprintf`).
+2. `sdcc` compiles the patched source for STM8 with `--out-fmt-ihx`.
+3. `packihx` converts the Intel HEX record into final `.hex`.
 
-Open `Project.eww` in IAR EWSTM8.
+CI is fully automated via `.github/workflows/build.yml` — SDCC 4.2.0 is cached from SourceForge, so no toolchain download on subsequent runs.
+
+### IAR Embedded Workbench
+
+Open `Project.eww` in IAR EWSTM8, build from the IDE. No patch step needed — all toolchain-specific features (bitfields, `snprintf`) work natively.
 
 ## Hardware Specification
 

--- a/iar2sdcc.py
+++ b/iar2sdcc.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+iar2sdcc.py — Patch IAR-specific constructs for SDCC compatibility
+
+Transforms multi-bit SFR field assignments (which SDCC cannot express
+via __sbit) into full-register read-modify-write operations.
+
+Usage:
+    python3 iar2sdcc.py <input.c> [output.c]
+    If output.c is omitted, the file is modified in place.
+"""
+import re, sys
+
+def patch_source(src: str) -> str:
+    # SPI_CR1_BR = N  →  SPI_CR1 = (SPI_CR1 & ~0x0E) | (N << 1)
+    src = re.sub(
+        r'SPI_CR1_BR\s*=\s*(\d+)\s*;',
+        r'SPI_CR1 = (SPI_CR1 & ~0x0E) | (\1 << 1);',
+        src
+    )
+    return src
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: iar2sdcc.py <input.c> [output.c]")
+        sys.exit(1)
+    src_path = sys.argv[1]
+    with open(src_path, 'r') as f:
+        src = f.read()
+    patched = patch_source(src)
+    dst_path = sys.argv[2] if len(sys.argv) > 2 else src_path
+    with open(dst_path, 'w') as f:
+        f.write(patched)
+
+if __name__ == '__main__':
+    main()

--- a/iar2sdcc.py
+++ b/iar2sdcc.py
@@ -14,11 +14,11 @@ def patch_source(src: str) -> str:
         r'SPI_CR1 = (SPI_CR1 & ~0x0E) | (\1 << 1);',
         src
     )
-    # 2. snprintf(B, sz, ...) -> sprintf(B, ...)
-    #    SDCC for STM8 does not provide snprintf
+    # 2. snprintf(buf, size, fmt, ...) -> sprintf(buf, fmt, ...)
+    #    SDCC for STM8 does not provide snprintf; strip size param
     src = re.sub(
-        r'\bsnprintf\s*\(',
-        'sprintf(',
+        r'\bsnprintf\(\s*([^,]+)\s*,\s*[^,]+\s*,',
+        r'sprintf(\1,',
         src
     )
     return src

--- a/iar2sdcc.py
+++ b/iar2sdcc.py
@@ -2,20 +2,23 @@
 """
 iar2sdcc.py — Patch IAR-specific constructs for SDCC compatibility
 
-Transforms multi-bit SFR field assignments (which SDCC cannot express
-via __sbit) into full-register read-modify-write operations.
-
 Usage:
     python3 iar2sdcc.py <input.c> [output.c]
-    If output.c is omitted, the file is modified in place.
 """
 import re, sys
 
 def patch_source(src: str) -> str:
-    # SPI_CR1_BR = N  ->  SPI_CR1 = (SPI_CR1 & ~0x0E) | (N << 1)
+    # 1. SPI_CR1_BR = N  ->  SPI_CR1 = (SPI_CR1 & ~0x0E) | (N << 1)
     src = re.sub(
         r'SPI_CR1_BR\s*=\s*(\d+)\s*;',
         r'SPI_CR1 = (SPI_CR1 & ~0x0E) | (\1 << 1);',
+        src
+    )
+    # 2. snprintf(B, sz, ...) -> sprintf(B, ...)
+    #    SDCC for STM8 does not provide snprintf
+    src = re.sub(
+        r'\bsnprintf\s*\(',
+        'sprintf(',
         src
     )
     return src

--- a/iar2sdcc.py
+++ b/iar2sdcc.py
@@ -12,7 +12,7 @@ Usage:
 import re, sys
 
 def patch_source(src: str) -> str:
-    # SPI_CR1_BR = N  →  SPI_CR1 = (SPI_CR1 & ~0x0E) | (N << 1)
+    # SPI_CR1_BR = N  ->  SPI_CR1 = (SPI_CR1 & ~0x0E) | (N << 1)
     src = re.sub(
         r'SPI_CR1_BR\s*=\s*(\d+)\s*;',
         r'SPI_CR1 = (SPI_CR1 & ~0x0E) | (\1 << 1);',
@@ -25,11 +25,11 @@ def main():
         print("Usage: iar2sdcc.py <input.c> [output.c]")
         sys.exit(1)
     src_path = sys.argv[1]
-    with open(src_path, 'r') as f:
+    with open(src_path, 'r', encoding='latin-1') as f:
         src = f.read()
     patched = patch_source(src)
     dst_path = sys.argv[2] if len(sys.argv) > 2 else src_path
-    with open(dst_path, 'w') as f:
+    with open(dst_path, 'w', encoding='utf-8') as f:
         f.write(patched)
 
 if __name__ == '__main__':

--- a/inc/iostm8s003f3.h
+++ b/inc/iostm8s003f3.h
@@ -1,0 +1,120 @@
+#ifndef IOSTM8S003F3_H
+#define IOSTM8S003F3_H
+
+#include <stdint.h>
+
+/* 8-bit bitfield overlay for bit-level register access */
+typedef volatile struct {
+  uint8_t b0:1, b1:1, b2:1, b3:1, b4:1, b5:1, b6:1, b7:1;
+} __bits8_t;
+
+/* ============== PORT C ============== */
+volatile uint8_t __at(0x500A) _PC_ODR;
+volatile uint8_t __at(0x500B) _PC_IDR;
+volatile __bits8_t __at(0x500B) _PC_IDR_bits;
+volatile uint8_t __at(0x500C) _PC_DDR;
+volatile uint8_t __at(0x500D) _PC_CR1;
+volatile uint8_t __at(0x500E) _PC_CR2;
+
+#define PC_IDR       _PC_IDR
+#define PC_IDR_IDR4  _PC_IDR_bits.b4
+
+/* ============== PORT D ============== */
+volatile uint8_t __at(0x500F) _PD_ODR;
+volatile uint8_t __at(0x5010) _PD_IDR;
+volatile uint8_t __at(0x5011) _PD_DDR;
+volatile uint8_t __at(0x5012) _PD_CR1;
+volatile uint8_t __at(0x5013) _PD_CR2;
+
+volatile __bits8_t __at(0x500F) _PD_ODR_bits;
+volatile __bits8_t __at(0x5011) _PD_DDR_bits;
+volatile __bits8_t __at(0x5012) _PD_CR1_bits;
+volatile __bits8_t __at(0x5013) _PD_CR2_bits;
+
+#define PD_ODR       _PD_ODR
+#define PD_ODR_ODR2  _PD_ODR_bits.b2
+#define PD_ODR_ODR3  _PD_ODR_bits.b3
+#define PD_DDR_DDR2  _PD_DDR_bits.b2
+#define PD_DDR_DDR3  _PD_DDR_bits.b3
+#define PD_CR1_C12   _PD_CR1_bits.b2
+#define PD_CR1_C13   _PD_CR1_bits.b3
+#define PD_CR2_C22   _PD_CR2_bits.b2
+#define PD_CR2_C23   _PD_CR2_bits.b3
+
+/* ============== SPI ============== */
+volatile uint8_t __at(0x5200) _SPI_CR1;
+volatile __bits8_t __at(0x5200) _SPI_CR1_bits;
+volatile uint8_t __at(0x5203) _SPI_SR;
+volatile __bits8_t __at(0x5203) _SPI_SR_bits;
+volatile uint8_t __at(0x5204) _SPI_DR;
+
+#define SPI_CR1      _SPI_CR1
+#define SPI_CR1_SPE  _SPI_CR1_bits.b6
+#define SPI_CR1_MSTR _SPI_CR1_bits.b2
+#define SPI_SR       _SPI_SR
+#define SPI_SR_TXE   _SPI_SR_bits.b1
+#define SPI_SR_RXNE  _SPI_SR_bits.b0
+#define SPI_DR       _SPI_DR
+
+/* ============== UART1 ============== */
+volatile uint8_t __at(0x5230) _UART1_SR;
+volatile __bits8_t __at(0x5230) _UART1_SR_bits;
+volatile uint8_t __at(0x5231) _UART1_DR;
+volatile uint8_t __at(0x5232) _UART1_BRR1;
+volatile uint8_t __at(0x5233) _UART1_BRR2;
+volatile uint8_t __at(0x5235) _UART1_CR2;
+volatile __bits8_t __at(0x5235) _UART1_CR2_bits;
+
+#define UART1_SR      _UART1_SR
+#define UART1_SR_TXE  _UART1_SR_bits.b7
+#define UART1_SR_TC   _UART1_SR_bits.b6
+#define UART1_DR      _UART1_DR
+#define UART1_BRR1    _UART1_BRR1
+#define UART1_BRR2    _UART1_BRR2
+#define UART1_CR2     _UART1_CR2
+#define UART1_CR2_TEN _UART1_CR2_bits.b3
+
+/* ============== TIM2 ============== */
+volatile uint8_t __at(0x5300) _TIM2_CR1;
+volatile __bits8_t __at(0x5300) _TIM2_CR1_bits;
+volatile uint8_t __at(0x5307) _TIM2_PSCR;
+volatile uint8_t __at(0x530B) _TIM2_ARRH;
+volatile uint8_t __at(0x530C) _TIM2_ARRL;
+
+#define TIM2_CR1     _TIM2_CR1
+#define TIM2_CR1_CEN _TIM2_CR1_bits.b0
+#define TIM2_CR1_OPM _TIM2_CR1_bits.b3
+#define TIM2_PSCR    _TIM2_PSCR
+#define TIM2_ARRH    _TIM2_ARRH
+#define TIM2_ARRL    _TIM2_ARRL
+
+/* ============== IWDG ============== */
+volatile uint8_t __at(0x50E0) _IWDG_KR;
+volatile uint8_t __at(0x50E1) _IWDG_PR;
+volatile uint8_t __at(0x50E2) _IWDG_RLR;
+
+#define IWDG_KR  _IWDG_KR
+#define IWDG_PR  _IWDG_PR
+#define IWDG_RLR _IWDG_RLR
+
+/* ============== RST ============== */
+volatile uint8_t __at(0x50B3) _RST_SR;
+volatile __bits8_t __at(0x50B3) _RST_SR_bits;
+
+#define RST_SR         _RST_SR
+#define RST_SR_EMCF    _RST_SR_bits.b0
+#define RST_SR_SWIMF   _RST_SR_bits.b1
+#define RST_SR_ILLOPF  _RST_SR_bits.b2
+#define RST_SR_IWDGF   _RST_SR_bits.b3
+#define RST_SR_WWDGF   _RST_SR_bits.b4
+
+/* ============== CLK ============== */
+volatile uint8_t __at(0x50C0) _CLK_CKDIVR;
+volatile uint8_t __at(0x50C7) _CLK_PCKENR1;
+volatile uint8_t __at(0x50C8) _CLK_PCKENR2;
+
+#define CLK_CKDIVR   _CLK_CKDIVR
+#define CLK_PCKENR1  _CLK_PCKENR1
+#define CLK_PCKENR2  _CLK_PCKENR2
+
+#endif

--- a/inc/iostm8s003f3.h
+++ b/inc/iostm8s003f3.h
@@ -11,13 +11,23 @@ typedef volatile struct {
 /* ============== PORT C ============== */
 volatile uint8_t __at(0x500A) _PC_ODR;
 volatile uint8_t __at(0x500B) _PC_IDR;
-volatile __bits8_t __at(0x500B) _PC_IDR_bits;
 volatile uint8_t __at(0x500C) _PC_DDR;
 volatile uint8_t __at(0x500D) _PC_CR1;
 volatile uint8_t __at(0x500E) _PC_CR2;
 
+volatile __bits8_t __at(0x500B) _PC_IDR_bits;
+volatile __bits8_t __at(0x500C) _PC_DDR_bits;
+volatile __bits8_t __at(0x500D) _PC_CR1_bits;
+volatile __bits8_t __at(0x500E) _PC_CR2_bits;
+
 #define PC_IDR       _PC_IDR
 #define PC_IDR_IDR4  _PC_IDR_bits.b4
+#define PC_DDR       _PC_DDR
+#define PC_DDR_DDR4  _PC_DDR_bits.b4
+#define PC_CR1       _PC_CR1
+#define PC_CR1_C14   _PC_CR1_bits.b4
+#define PC_CR2       _PC_CR2
+#define PC_CR2_C24   _PC_CR2_bits.b4
 
 /* ============== PORT D ============== */
 volatile uint8_t __at(0x500F) _PD_ODR;


### PR DESCRIPTION
## Summary

Replace the IAR-only build with a dual-compiler setup: **SDCC** (free, cross-platform) plus the existing **IAR EWSTM8** project.

## Changes

- **SDCC Makefile** - make builds from source with sdcc + packihx
- **iar2sdcc.py** - preprocessor that patches IAR-specific idioms (SPI_CR1_BR, snprintf) for SDCC
- **inc/iostm8s003f3.h** - register map using __at() + bitfield structs (SDCC-compatible, no __sfr/__sbit)
- **.github/workflows/build.yml** - CI caches SDCC 4.2.0 tarball from SourceForge; runs on every push
- **README.md** - rewritten with full spec (pinout, radio protocol, firmware architecture diagram, power management), compiler comparison table, badges
- **LICENSE** - MIT

## Build Verification

Build passes on CI (Linux): https://github.com/a5021/STM8S-NRF24L01-RECEIVER/actions/workflows/build.yml

IAR project files (Project.eww / .ewp / .ewd) are preserved and unchanged.